### PR TITLE
Feature/fix header and text color

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,7 +21,7 @@ export default function Home() {
       <main className="mx-auto w-full">
         <section className="pt-40 pb-32 border-b">
           <div className="flex flex-col gap-24 container">
-            <div className="flex lg:grid lg:grid-cols-2 gap-12 justify-between lg:gap-0 items-center">
+            <div className="lg:grid lg:grid-cols-2 flex justify-between items-center">
               <div className="flex flex-col w-full gap-6">
                 <h1 className="text-6xl lg:text-7xl text-center md:text-left font-bold-condensed -tracking-[0.175rem] w-full">
                   INSIGHTS FOR THE MODERN MARKETER

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -42,7 +42,7 @@ const config = {
         foreground: 'hsl(var(--foreground))',
         primary: {
           DEFAULT: '#030712',
-          foreground: 'hsl(var(--primary-foreground))',
+          foreground: 'rgb(var(--primary-foreground))',
         },
         secondary: {
           DEFAULT: 'hsl(var(--secondary))',


### PR DESCRIPTION
Home header:

* [`src/app/page.tsx`](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL24-R24): Modified the `div` structure inside the `Home` component to stop using gap unnecessarily (caused it not to be centered on mobile).
![image](https://github.com/user-attachments/assets/8261adec-63f2-4ff1-9731-54567c0613e8)


Color configuration update:

* [`tailwind.config.ts`](diffhunk://#diff-655dc9e3d0aa561e3fa164bf48bd89cb0f5da65e0a567f8ebbf9dd791a0e7f40L45-R45): Updated the `foreground` property of the `primary` color from `hsl` to `rgb` to fix incompatibility issue.

![image](https://github.com/user-attachments/assets/68c8d27b-4bcc-4c58-95a8-ce6eeb4e9274)
![image](https://github.com/user-attachments/assets/07605648-fdf9-4415-8c30-08dc7698ecab)

